### PR TITLE
Configure Read The Docs for PySift documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11.5"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ release = '0.1.0'
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = []
+extensions = ['sphinx.ext.autodoc']
 
 templates_path = ['_templates']
 exclude_patterns = []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-PySift documentation
+Welcome to PySift!
 ====================
 
 Add your content using ``reStructuredText`` syntax. See the
@@ -14,4 +14,12 @@ documentation for details.
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+   
+   installation
 
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,18 @@
+Installation
+============
+
+There are two ways to install PySift: using pip or from source.
+
+1. To install PySift, use pip:
+
+.. code-block:: bash
+    
+    pip install pysift
+
+2. To install PySift from source, clone the repository and run the setup script:
+
+.. code-block:: bash
+
+    git clone https://github.com/E-X-P-L-O-R-E/PySift.git
+    cd PySift
+    python setup.py install

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,7 @@
 sphinx
+requests_mock
+PyYAML==6.0.1
+clyent==1.2.1
+requests==2.31.0
+pytest
+sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,27 +12,53 @@ certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
+clyent==1.2.1
+    # via -r requirements.in
 colorama==0.4.6
-    # via sphinx
+    # via
+    #   pytest
+    #   sphinx
 docutils==0.21.2
-    # via sphinx
+    # via
+    #   sphinx
+    #   sphinx-rtd-theme
 idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
+iniconfig==2.0.0
+    # via pytest
 jinja2==3.1.4
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
 packaging==24.1
-    # via sphinx
+    # via
+    #   pytest
+    #   sphinx
+pluggy==1.5.0
+    # via pytest
 pygments==2.18.0
     # via sphinx
-requests==2.32.3
-    # via sphinx
+pytest==8.3.3
+    # via -r requirements.in
+pyyaml==6.0.1
+    # via -r requirements.in
+requests==2.31.0
+    # via
+    #   -r requirements.in
+    #   requests-mock
+    #   sphinx
+requests-mock==1.12.1
+    # via -r requirements.in
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==8.0.2
+    # via
+    #   -r requirements.in
+    #   sphinx-rtd-theme
+    #   sphinxcontrib-jquery
+sphinx-rtd-theme==3.0.1
     # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -40,6 +66,8 @@ sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
+sphinxcontrib-jquery==4.1
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==2.0.0


### PR DESCRIPTION
This PR adds support for hosting `PySift`'s documentation on `Read The Docs (RTD)` for easy accessibility.